### PR TITLE
fix: harden Linux sidecar discovery

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -6,7 +6,7 @@
 //
 // The sidecar (language_server_{platform}) runs a ConnectRPC server on a dynamic HTTPS port
 // with CSRF tokens. We discover these from the process command line at runtime.
-// Binary names: Windows=language_server_windows_x64.exe, macOS=language_server_macos, Linux=language_server_linux
+// Binary names: Windows=language_server_windows_x64.exe, macOS=language_server_macos, Linux=language_server_linux_x64
 
 'use strict';
 

--- a/src/handlers/chat.js
+++ b/src/handlers/chat.js
@@ -12,6 +12,27 @@ const { callSidecarChat } = require('../sidecar/cascade');
 // POST /v1/chat/completions
 // ─────────────────────────────────────────────
 
+async function dispatchViaAntigravityCommand(userMessage) {
+  const allCommands = await vscode.commands.getCommands(true);
+  const command = ['antigravity.executeCascadeAction'].find((candidate) => allCommands.includes(candidate));
+
+  if (!command) {
+    const relatedCommands = allCommands.filter(
+      (name) =>
+        name.toLowerCase().includes('antigravity') ||
+        name.toLowerCase().includes('jetski') ||
+        name.toLowerCase().includes('cascade'),
+    );
+    const sample = relatedCommands.slice(0, 8).join(', ') || 'none';
+    throw new Error(`No supported Antigravity command-dispatch command found. Related commands: ${sample}`);
+  }
+
+  await vscode.commands.executeCommand(command, {
+    type: 'sendMessage',
+    message: userMessage,
+  });
+}
+
 async function handleChatCompletions(ctx, req, res) {
   const body = await readBody(req);
   let payload;
@@ -156,10 +177,7 @@ async function _handleChatCompletionsInner(
       .map((m) => extractText(m.content))
       .join('\n');
     log(ctx, `⚠️ Falling back to Tier 2 command dispatch (sidecar unavailable)`);
-    await vscode.commands.executeCommand('antigravity.executeCascadeAction', {
-      type: 'sendMessage',
-      message: userMessage,
-    });
+    await dispatchViaAntigravityCommand(userMessage);
     const text = '[Message dispatched to Antigravity agent panel. Check the Antigravity chat panel for the response.]';
     if (isStream) {
       setupStreamResponse(res);

--- a/src/sidecar/discovery.js
+++ b/src/sidecar/discovery.js
@@ -21,18 +21,19 @@ const { log } = require('../utils');
 // ─────────────────────────────────────────────
 
 /**
- * Binary name the Antigravity sidecar ships as, per platform.
+ * Binary names the Antigravity sidecar has shipped as, per platform.
  */
 const SIDECAR_BINARY_NAMES = {
-  win32: 'language_server_windows_x64.exe',
-  darwin: 'language_server_macos',
-  linux: 'language_server_linux',
+  win32: ['language_server_windows_x64.exe'],
+  darwin: ['language_server_macos'],
+  linux: ['language_server_linux_x64', 'language_server_linux'],
 };
 
 /**
  * @typedef {Object} ProcessInfo
  * @property {string} pid
  * @property {string} commandLine
+ * @property {string} user
  */
 
 /**
@@ -41,28 +42,60 @@ const SIDECAR_BINARY_NAMES = {
  * @property {(pid: string) => Promise<number[]>} findListeningPorts
  */
 
+function rankProcessCandidate(proc) {
+  const user = (() => {
+    try {
+      return os.userInfo().username;
+    } catch {
+      return null;
+    }
+  })();
+
+  let score = 0;
+  if (proc.commandLine.includes('/resources/app/extensions/antigravity/bin/')) score += 100;
+  if (proc.commandLine.includes('--extension_server_csrf_token')) score += 50;
+  if (proc.commandLine.includes('--random_port')) score += 20;
+  if (proc.commandLine.includes('--server_port')) score += 10;
+  if (user && proc.user === user) score += 30;
+  if (proc.commandLine.startsWith('/usr/local/bin/')) score -= 40;
+  return score;
+}
+
+function chooseBestProcess(candidates) {
+  if (!candidates || candidates.length === 0) return null;
+  return [...candidates].sort((a, b) => rankProcessCandidate(b) - rankProcessCandidate(a))[0];
+}
+
 // ─────────────────────────────────────────────
 // Windows strategy  (PowerShell Get-CimInstance)
 // ─────────────────────────────────────────────
 
-function windowsStrategy(binaryName) {
+function windowsStrategy(binaryNames) {
   return {
     async findProcess() {
-      // Use Get-CimInstance Win32_Process (preferred over deprecated wmic)
-      const psCmd = `Get-CimInstance Win32_Process -Filter "Name='${binaryName}'" | Select-Object ProcessId,CommandLine | Format-List`;
-      const { stdout } = await execFileAsync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', psCmd], {
-        encoding: 'utf8',
-        timeout: 10000,
-      });
+      for (const binaryName of binaryNames) {
+        // Use Get-CimInstance Win32_Process (preferred over deprecated wmic)
+        const psCmd = `Get-CimInstance Win32_Process -Filter "Name='${binaryName}'" | Select-Object ProcessId,CommandLine | Format-List`;
+        const { stdout } = await execFileAsync(
+          'powershell.exe',
+          ['-NoProfile', '-NonInteractive', '-Command', psCmd],
+          {
+            encoding: 'utf8',
+            timeout: 10000,
+          },
+        );
 
-      if (!stdout || !stdout.trim()) return null;
+        if (!stdout || !stdout.trim()) continue;
 
-      const pidMatch = stdout.match(/ProcessId\s*:\s*(\d+)/);
-      const cmdMatch = stdout.match(/CommandLine\s*:\s*(.+)/);
+        const pidMatch = stdout.match(/ProcessId\s*:\s*(\d+)/);
+        const cmdMatch = stdout.match(/CommandLine\s*:\s*(.+)/);
 
-      if (!pidMatch || !cmdMatch) return null;
+        if (pidMatch && cmdMatch) {
+          return { pid: pidMatch[1], commandLine: cmdMatch[1].trim(), user: '' };
+        }
+      }
 
-      return { pid: pidMatch[1], commandLine: cmdMatch[1].trim() };
+      return null;
     },
 
     async findListeningPorts(pid) {
@@ -87,22 +120,25 @@ function windowsStrategy(binaryName) {
 // macOS strategy  (ps aux + lsof)
 // ─────────────────────────────────────────────
 
-function darwinStrategy(binaryName) {
+function darwinStrategy(binaryNames) {
   return {
     async findProcess() {
       const { stdout } = await execFileAsync('/bin/ps', ['aux'], { encoding: 'utf8', timeout: 5000 });
 
-      // Find the line that contains the actual binary (skip the grep line)
-      const line = stdout.split('\n').find((l) => l.includes(binaryName) && !l.includes('grep'));
-      if (!line) return null;
+      const candidates = stdout
+        .split('\n')
+        .filter((l) => binaryNames.some((binaryName) => l.includes(binaryName)) && !l.includes('grep'))
+        .map((line) => {
+          const parts = line.trim().split(/\s+/);
+          return {
+            user: parts[0],
+            pid: parts[1],
+            commandLine: parts.slice(10).join(' '),
+          };
+        })
+        .filter((proc) => proc.pid && proc.commandLine);
 
-      // ps aux columns: USER PID %CPU %MEM VSZ RSS TTY STAT START TIME COMMAND...
-      const parts = line.trim().split(/\s+/);
-      const pid = parts[1];
-      // Reconstruct full command line from column 10 onward
-      const commandLine = parts.slice(10).join(' ');
-
-      return { pid, commandLine };
+      return chooseBestProcess(candidates);
     },
 
     async findListeningPorts(pid) {
@@ -129,19 +165,25 @@ function darwinStrategy(binaryName) {
 // Linux strategy  (ps aux + ss)
 // ─────────────────────────────────────────────
 
-function linuxStrategy(binaryName) {
+function linuxStrategy(binaryNames) {
   return {
     async findProcess() {
       const { stdout } = await execFileAsync('/bin/ps', ['aux'], { encoding: 'utf8', timeout: 5000 });
 
-      const line = stdout.split('\n').find((l) => l.includes(binaryName) && !l.includes('grep'));
-      if (!line) return null;
+      const candidates = stdout
+        .split('\n')
+        .filter((l) => binaryNames.some((binaryName) => l.includes(binaryName)) && !l.includes('grep'))
+        .map((line) => {
+          const parts = line.trim().split(/\s+/);
+          return {
+            user: parts[0],
+            pid: parts[1],
+            commandLine: parts.slice(10).join(' '),
+          };
+        })
+        .filter((proc) => proc.pid && proc.commandLine);
 
-      const parts = line.trim().split(/\s+/);
-      const pid = parts[1];
-      const commandLine = parts.slice(10).join(' ');
-
-      return { pid, commandLine };
+      return chooseBestProcess(candidates);
     },
 
     async findListeningPorts(pid) {
@@ -169,13 +211,13 @@ function linuxStrategy(binaryName) {
 
 /**
  * Return the correct strategy for the current platform.
- * @returns {{ strategy: PlatformStrategy, binaryName: string }}
+ * @returns {{ strategy: PlatformStrategy, binaryNames: string[] }}
  */
 function getPlatformStrategy() {
   const platform = os.platform();
-  const binaryName = SIDECAR_BINARY_NAMES[platform];
+  const binaryNames = SIDECAR_BINARY_NAMES[platform];
 
-  if (!binaryName) {
+  if (!binaryNames) {
     throw new Error(`Unsupported platform for sidecar discovery: ${platform}`);
   }
 
@@ -185,7 +227,7 @@ function getPlatformStrategy() {
     linux: linuxStrategy,
   };
 
-  return { strategy: factories[platform](binaryName), binaryName };
+  return { strategy: factories[platform](binaryNames), binaryNames };
 }
 
 // ─────────────────────────────────────────────
@@ -196,12 +238,12 @@ async function discoverSidecar(ctx) {
   if (ctx.sidecarInfo && Date.now() - ctx.sidecarInfoTimestamp < ctx.SIDECAR_CACHE_TTL) return ctx.sidecarInfo;
 
   try {
-    const { strategy, binaryName } = getPlatformStrategy();
+    const { strategy, binaryNames } = getPlatformStrategy();
 
     // 1. Find the sidecar process
     const proc = await strategy.findProcess();
     if (!proc) {
-      log(ctx, `⚠️ Sidecar process not found (looking for ${binaryName} on ${os.platform()})`);
+      log(ctx, `⚠️ Sidecar process not found (looking for ${binaryNames.join(', ')} on ${os.platform()})`);
       return null;
     }
 
@@ -211,6 +253,8 @@ async function discoverSidecar(ctx) {
     const extPortMatch = commandLine.match(/--extension_server_port\s+(\d+)/);
     const extCsrfMatch = commandLine.match(/--extension_server_csrf_token\s+([a-f0-9-]+)/);
     const mainCsrfMatch = commandLine.match(/--csrf_token\s+([a-f0-9-]+)/);
+    const serverPortMatch = commandLine.match(/--server_port\s+(\d+)/);
+    const lspPortMatch = commandLine.match(/--lsp_port[= ](\d+)/);
 
     if (!extPortMatch) {
       log(ctx, '⚠️ Could not find sidecar extension_server_port');
@@ -234,7 +278,11 @@ async function discoverSidecar(ctx) {
     if (extCsrfMatch) csrfTokens.push(extCsrfMatch[1]);
 
     // 6. Collect ports (extension_server_port first, then any discovered listening ports)
-    const portsToTry = [...new Set([parseInt(extPortMatch[1]), ...actualPorts])];
+    const portsToTry = [
+      ...new Set(
+        [parseInt(extPortMatch[1]), serverPortMatch && parseInt(serverPortMatch[1]), lspPortMatch && parseInt(lspPortMatch[1]), ...actualPorts].filter(Boolean),
+      ),
+    ];
 
     ctx.sidecarInfo = {
       extensionServerPort: parseInt(extPortMatch[1]),

--- a/test/__mocks__/vscode.js
+++ b/test/__mocks__/vscode.js
@@ -36,6 +36,7 @@ module.exports = {
   commands: {
     registerCommand: () => ({ dispose: () => {} }),
     executeCommand: async () => {},
+    getCommands: async () => [],
   },
   extensions: {
     getExtension: () => null,

--- a/test/discovery.test.js
+++ b/test/discovery.test.js
@@ -1,0 +1,150 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const childProcess = require('child_process');
+const os = require('os');
+const { promisify } = require('util');
+
+const discoveryModulePath = require.resolve('../src/sidecar/discovery');
+
+function loadDiscoveryWithPlatform(platform, commandOutputs = {}) {
+  const calls = [];
+  const originalExecFile = childProcess.execFile;
+  const originalPlatform = os.platform;
+
+  const execFileStub = (file, args, options, callback) => {
+    if (typeof options === 'function') {
+      callback = options;
+    }
+
+    calls.push({ file, args });
+    const output = commandOutputs[file] || { stdout: '', stderr: '' };
+    callback(null, output.stdout || '', output.stderr || '');
+  };
+  execFileStub[promisify.custom] = async (file, args) => {
+    calls.push({ file, args });
+    const output = commandOutputs[file] || { stdout: '', stderr: '' };
+    return { stdout: output.stdout || '', stderr: output.stderr || '' };
+  };
+
+  childProcess.execFile = execFileStub;
+  os.platform = () => platform;
+  delete require.cache[discoveryModulePath];
+
+  return {
+    calls,
+    discovery: require('../src/sidecar/discovery'),
+    restore() {
+      childProcess.execFile = originalExecFile;
+      os.platform = originalPlatform;
+      delete require.cache[discoveryModulePath];
+    },
+  };
+}
+
+function createCtx() {
+  return {
+    sidecarInfo: null,
+    sidecarInfoTimestamp: 0,
+    SIDECAR_CACHE_TTL: 0,
+    outputChannel: { appendLine: () => {} },
+  };
+}
+
+describe('discoverSidecar platform dispatch', () => {
+  it('discovers the live linux x64 sidecar binary variant', async () => {
+    const harness = loadDiscoveryWithPlatform('linux', {
+      '/bin/ps': {
+        stdout:
+          'USER PID %CPU %MEM VSZ RSS TTY STAT START TIME COMMAND\n' +
+          'fedora 616032 0.0 0.1 123 456 ? Sl 11:18 0:03 /usr/share/antigravity/resources/app/extensions/antigravity/bin/language_server_linux_x64 --enable_lsp --csrf_token 5772a62d-9302-4825-a701-1a85cbe3bc01 --extension_server_port 40759 --extension_server_csrf_token 00dc95ac-46dd-4443-8d5a-a2f33782bb02\n',
+      },
+      ss: {
+        stdout:
+          'State  Recv-Q Send-Q Local Address:Port  Peer Address:PortProcess\n' +
+          'LISTEN 0      511        127.0.0.1:40759      0.0.0.0:*    users:((\"language_server_linux_x64\",pid=616032,fd=30))\n' +
+          'LISTEN 0      511        127.0.0.1:39201      0.0.0.0:*    users:((\"language_server_linux_x64\",pid=616032,fd=31))\n',
+      },
+    });
+
+    try {
+      const result = await harness.discovery.discoverSidecar(createCtx());
+      assert.equal(result.extensionServerPort, 40759);
+      assert.deepEqual(result.actualPorts, [40759, 39201]);
+      assert.deepEqual(result.csrfTokens, [
+        '5772a62d-9302-4825-a701-1a85cbe3bc01',
+        '00dc95ac-46dd-4443-8d5a-a2f33782bb02',
+      ]);
+    } finally {
+      harness.restore();
+    }
+  });
+
+  it('prefers the Antigravity extension sidecar over a stray local binary', async () => {
+    const harness = loadDiscoveryWithPlatform('linux', {
+      '/bin/ps': {
+        stdout:
+          'USER PID %CPU %MEM VSZ RSS TTY STAT START TIME COMMAND\n' +
+          'root 612966 0.0 0.1 123 456 ? Sl 11:17 0:03 /usr/local/bin/language_server_linux_x64 --enable_lsp --lsp_port=36999 --extension_server_port 38943 --csrf_token e56fcd85-8ef7-4516-941f-424d98193c9f --server_port 43873\n' +
+          'fedora-rog 639160 0.0 0.1 123 456 ? Sl 11:31 0:03 /usr/share/antigravity/resources/app/extensions/antigravity/bin/language_server_linux_x64 --enable_lsp --csrf_token 6830c0ad-2ffd-493b-913d-f0207685cf2c --extension_server_port 46237 --extension_server_csrf_token 1ad08e9c-3424-43ca-b40e-c42b6248f017 --random_port\n',
+      },
+      ss: {
+        stdout:
+          'State  Recv-Q Send-Q Local Address:Port  Peer Address:PortProcess\n' +
+          'LISTEN 0      511        127.0.0.1:46237      0.0.0.0:*    users:((\"antigravity\",pid=639041,fd=48))\n' +
+          'LISTEN 0      4096       127.0.0.1:43405      0.0.0.0:*    users:((\"language_server\",pid=639160,fd=9))\n' +
+          'LISTEN 0      4096       127.0.0.1:40935      0.0.0.0:*    users:((\"language_server\",pid=639160,fd=10))\n',
+      },
+    });
+
+    try {
+      const result = await harness.discovery.discoverSidecar(createCtx());
+      assert.equal(result.pid, '639160');
+      assert.equal(result.extensionServerPort, 46237);
+      assert.deepEqual(result.actualPorts, [46237, 43405, 40935]);
+      assert.deepEqual(result.csrfTokens, [
+        '6830c0ad-2ffd-493b-913d-f0207685cf2c',
+        '1ad08e9c-3424-43ca-b40e-c42b6248f017',
+      ]);
+    } finally {
+      harness.restore();
+    }
+  });
+
+  it('uses Linux process inspection on linux', async () => {
+    const harness = loadDiscoveryWithPlatform('linux', {
+      '/bin/ps': { stdout: 'USER PID %CPU %MEM VSZ RSS TTY STAT START TIME COMMAND\n' },
+    });
+
+    try {
+      const result = await harness.discovery.discoverSidecar(createCtx());
+      assert.equal(result, null);
+      assert.deepEqual(
+        harness.calls.map((call) => call.file),
+        ['/bin/ps'],
+      );
+      assert.ok(!harness.calls.some((call) => call.file === 'powershell.exe'));
+    } finally {
+      harness.restore();
+    }
+  });
+
+  it('uses PowerShell process inspection on win32', async () => {
+    const harness = loadDiscoveryWithPlatform('win32', {
+      'powershell.exe': { stdout: '' },
+    });
+
+    try {
+      const result = await harness.discovery.discoverSidecar(createCtx());
+      assert.equal(result, null);
+      assert.deepEqual(
+        harness.calls.map((call) => call.file),
+        ['powershell.exe'],
+      );
+      assert.ok(!harness.calls.some((call) => call.file === '/bin/ps'));
+    } finally {
+      harness.restore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- support current Linux sidecar binary variants and score multiple matching processes instead of taking the first one
- prefer the Antigravity extension-owned sidecar over stray local language server processes
- surface a clearer Tier 2 fallback error when no supported Antigravity dispatch command exists
- add regression coverage for Linux discovery routing and sidecar candidate selection

## Verification
- `npm test`
- verified live `curl /v1/chat/completions` now succeeds through Tier 1 sidecar flow

## Notes
- `npm run lint` could not run in this checkout because `node_modules` is missing and the local `eslint` binary is unavailable