### PR TITLE
Add Gemini 3.5 Flash tiers; return 404 for unknown models instead of silently routing to the default

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -145,8 +145,11 @@ Bypasses Cascade entirely — calls `GetModelResponse` directly on the sidecar.
 - Formats OpenAI messages into a flat prompt string with role labels
 - Parses `<tool_call>{...}</tool_call>` blocks back into OpenAI `tool_calls` format
 - Timeout: **15 minutes** (LLM inference can be very slow)
-- Model enum values: `MODEL_PLACEHOLDER_M18` (Flash), `MODEL_PLACEHOLDER_M16` (Pro High),
+- Model enum values: `MODEL_PLACEHOLDER_M18` (Flash), `MODEL_PLACEHOLDER_M132` (3.5 Flash High),
+  `MODEL_PLACEHOLDER_M20` (3.5 Flash Medium), `MODEL_PLACEHOLDER_M187` (3.5 Flash Low), `MODEL_PLACEHOLDER_M16` (Pro High),
   `MODEL_PLACEHOLDER_M36` (Pro Low), `MODEL_PLACEHOLDER_M35` (Sonnet), `MODEL_PLACEHOLDER_M26` (Opus), `MODEL_OPENAI_GPT_OSS_120B_MEDIUM` (GPT-OSS 120B)
+- The authoritative label ↔ enum-name table can be queried live from the sidecar via the
+  `GetCascadeModelConfigData` RPC (e.g. through the bridge's own `/v1/proxy` debug endpoint)
 - **Auth re-discovery**: On `PERMISSION_DENIED` / `401` / `403` in the raw response body,
   `ctx.sidecarInfo` is cleared to force re-discovery on the next request (handles CSRF rotation).
 
@@ -218,4 +221,11 @@ and short-form aliases (hidden from model list) for compatibility with other too
 | `gemini-3.1-pro-high`      | `antigravity-gemini-3.1-pro-high`      | 1037       |
 | `gemini-3.1-pro-low`       | `antigravity-gemini-3.1-pro-low`       | 1036       |
 | `gemini-3-flash-agent`     | `antigravity-gemini-3-flash`           | 1018       |
+| `gemini-3.5-flash`         | `antigravity-gemini-3.5-flash`         | 1040 ⚠     |
+| `gemini-3.5-flash-medium`  | `antigravity-gemini-3.5-flash-medium`  | 1041 ⚠     |
+| `gemini-3.5-flash-low`     | `antigravity-gemini-3.5-flash-low`     | 1042 ⚠     |
+
+⚠ Values 1040–1042 are **bridge-internal indices only**, not Cascade wire enums — the
+`GetCascadeModelConfigData` RPC exposes string enum names without numerics. Do not add
+them to the protobuf maps in `src/sidecar/proto.js` / `src/sidecar/raw.js`.
 | `gpt-oss-120b-medium`      | `antigravity-gpt-oss-120b`             | 342        |

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ The extension runs inside Antigravity's VS Code process, discovers the sidecar v
 | `antigravity-claude-sonnet-4-6`        | Claude Sonnet 4.6 with Thinking **(default)** |
 | `antigravity-claude-opus-4-6-thinking` | Claude Opus 4.6 with Thinking                 |
 | `antigravity-gemini-3-flash`           | Gemini 3 Flash                                |
+| `antigravity-gemini-3.5-flash`         | Gemini 3.5 Flash — High thinking              |
+| `antigravity-gemini-3.5-flash-medium`  | Gemini 3.5 Flash — Medium thinking            |
+| `antigravity-gemini-3.5-flash-low`     | Gemini 3.5 Flash — Low thinking               |
 | `antigravity-gemini-3.1-pro-high`      | Gemini 3.1 Pro — High thinking                |
 | `antigravity-gemini-3.1-pro-low`       | Gemini 3.1 Pro — Low thinking                 |
 | `antigravity-gpt-oss-120b`             | GPT-OSS 120B Medium                           |

--- a/src/handlers/anthropic.js
+++ b/src/handlers/anthropic.js
@@ -10,6 +10,9 @@ const { sanitizeRequest } = require('../sanitize');
 // Map numeric model enum values → GetModelResponse string enum (same as chat.js)
 const VALUE_TO_MODEL_ENUM = {
   1018: 'MODEL_PLACEHOLDER_M18', // Flash
+  1040: 'MODEL_PLACEHOLDER_M132', // 3.5 Flash High
+  1041: 'MODEL_PLACEHOLDER_M20', // 3.5 Flash Medium
+  1042: 'MODEL_PLACEHOLDER_M187', // 3.5 Flash Low
   1037: 'MODEL_PLACEHOLDER_M16', // Pro High
   1036: 'MODEL_PLACEHOLDER_M36', // Pro Low
   1035: 'MODEL_PLACEHOLDER_M35', // Sonnet

--- a/src/handlers/anthropic.js
+++ b/src/handlers/anthropic.js
@@ -168,6 +168,12 @@ async function handleAnthropicMessages(ctx, req, res) {
 
   // Resolve model
   const resolved = resolveModel(payload.model);
+  if (!resolved) {
+    return sendJson(res, 404, {
+      type: 'error',
+      error: { type: 'not_found_error', message: `Unknown model '${payload.model}'. Use GET /v1/models for available ids.` },
+    });
+  }
   log(ctx, `📡 [Anthropic] Model: ${resolved.key} (enum=${resolved.value})`);
 
   const modelEnum = VALUE_TO_MODEL_ENUM[resolved.value];

--- a/src/handlers/gemini.js
+++ b/src/handlers/gemini.js
@@ -8,6 +8,9 @@ const { sanitizeRequest } = require('../sanitize');
 
 const VALUE_TO_MODEL_ENUM = {
   1018: 'MODEL_PLACEHOLDER_M18', // Flash
+  1040: 'MODEL_PLACEHOLDER_M132', // 3.5 Flash High
+  1041: 'MODEL_PLACEHOLDER_M20', // 3.5 Flash Medium
+  1042: 'MODEL_PLACEHOLDER_M187', // 3.5 Flash Low
   1037: 'MODEL_PLACEHOLDER_M16', // Pro High
   1036: 'MODEL_PLACEHOLDER_M36', // Pro Low
   1035: 'MODEL_PLACEHOLDER_M35', // Sonnet

--- a/src/handlers/gemini.js
+++ b/src/handlers/gemini.js
@@ -129,6 +129,15 @@ async function handleGeminiGenerateContent(ctx, req, res, modelFromPath) {
 
   // Resolve model — modelFromPath comes from the URL like "gemini-3.1-pro-high"
   const resolved = resolveModel(modelFromPath || payload.model);
+  if (!resolved) {
+    return sendJson(res, 404, {
+      error: {
+        code: 404,
+        message: `Unknown model '${modelFromPath || payload.model}'. Use GET /v1/models for available ids.`,
+        status: 'NOT_FOUND',
+      },
+    });
+  }
   log(ctx, `📡 [Gemini] Model: ${resolved.key} (enum=${resolved.value})`);
 
   const modelEnum = VALUE_TO_MODEL_ENUM[resolved.value];

--- a/src/handlers/openai.js
+++ b/src/handlers/openai.js
@@ -99,6 +99,15 @@ async function handleChatCompletions(ctx, req, res) {
 
   // Resolve model from request
   const resolved = resolveModel(payload.model);
+  if (!resolved) {
+    return sendJson(res, 404, {
+      error: {
+        message: `Unknown model '${payload.model}'. Use GET /v1/models for available ids.`,
+        type: 'invalid_request_error',
+        code: 'model_not_found',
+      },
+    });
+  }
   log(ctx, `📡 Model: ${resolved.key} (enum=${resolved.value})`);
 
   // Resolve workspace

--- a/src/handlers/openai.js
+++ b/src/handlers/openai.js
@@ -21,6 +21,9 @@ const { sanitizeRequest } = require('../sanitize');
 // Map numeric model enum values → GetModelResponse string enum
 const VALUE_TO_MODEL_ENUM = {
   1018: 'MODEL_PLACEHOLDER_M18', // Flash
+  1040: 'MODEL_PLACEHOLDER_M132', // 3.5 Flash High
+  1041: 'MODEL_PLACEHOLDER_M20', // 3.5 Flash Medium
+  1042: 'MODEL_PLACEHOLDER_M187', // 3.5 Flash Low
   1037: 'MODEL_PLACEHOLDER_M16', // Pro High
   1036: 'MODEL_PLACEHOLDER_M36', // Pro Low
   1035: 'MODEL_PLACEHOLDER_M35', // Sonnet

--- a/src/models.js
+++ b/src/models.js
@@ -13,6 +13,31 @@ const MODEL_MAP = {
     context: 1048576,
     output: 65536,
   },
+  // Gemini 3.5 Flash tiers — string enums confirmed against the sidecar's
+  // GetCascadeModelConfigData RPC (it returns label ↔ enum-name pairs only,
+  // so the numeric `value`s below are bridge-internal indices, not wire values;
+  // they must stay out of the Cascade protobuf maps in sidecar/raw.js & proto.js).
+  'antigravity-gemini-3.5-flash': {
+    value: 1040,
+    name: 'Gemini 3.5 Flash (High)',
+    owned_by: 'google',
+    context: 1048576,
+    output: 65536,
+  },
+  'antigravity-gemini-3.5-flash-medium': {
+    value: 1041,
+    name: 'Gemini 3.5 Flash (Medium)',
+    owned_by: 'google',
+    context: 1048576,
+    output: 65536,
+  },
+  'antigravity-gemini-3.5-flash-low': {
+    value: 1042,
+    name: 'Gemini 3.5 Flash (Low)',
+    owned_by: 'google',
+    context: 1048576,
+    output: 65536,
+  },
   'antigravity-gemini-3.1-pro-high': {
     value: 1037,
     name: 'Gemini 3.1 Pro (High)',
@@ -61,6 +86,30 @@ const MODEL_MAP = {
   'gemini-3-flash-agent': {
     value: 1018,
     name: 'Gemini 3 Flash',
+    owned_by: 'google',
+    context: 1048576,
+    output: 65536,
+    hidden: true,
+  },
+  'gemini-3.5-flash': {
+    value: 1040,
+    name: 'Gemini 3.5 Flash (High)',
+    owned_by: 'google',
+    context: 1048576,
+    output: 65536,
+    hidden: true,
+  },
+  'gemini-3.5-flash-medium': {
+    value: 1041,
+    name: 'Gemini 3.5 Flash (Medium)',
+    owned_by: 'google',
+    context: 1048576,
+    output: 65536,
+    hidden: true,
+  },
+  'gemini-3.5-flash-low': {
+    value: 1042,
+    name: 'Gemini 3.5 Flash (Low)',
     owned_by: 'google',
     context: 1048576,
     output: 65536,

--- a/src/models.js
+++ b/src/models.js
@@ -118,9 +118,15 @@ function resolveModel(requestedModel) {
   // Try partial match (e.g. "claude-sonnet" matches "claude-sonnet-4.6")
   const lower = requestedModel.toLowerCase();
   for (const [k, v] of Object.entries(MODEL_MAP)) {
+    // Skip the bare 'antigravity' alias here: every 'antigravity-*' id contains it,
+    // so any unknown 'antigravity-<model>' would silently resolve to the default model.
+    if (k === 'antigravity') continue;
     if (k.includes(lower) || lower.includes(k)) return { key: k, ...v };
   }
-  return { key: DEFAULT_MODEL_KEY, ...MODEL_MAP[DEFAULT_MODEL_KEY] };
+  // Unknown model: return null so handlers can reply 404. Falling back to the
+  // default model here would mean callers believe they are talking to the model
+  // they asked for while actually getting the default — undiagnosable misrouting.
+  return null;
 }
 
 module.exports = { MODEL_MAP, DEFAULT_MODEL_KEY, resolveModel };

--- a/src/sidecar/raw.js
+++ b/src/sidecar/raw.js
@@ -233,7 +233,12 @@ function enqueueInference(fn) {
 async function callRawInference(ctx, messages, modelEnum, tools = null, images = []) {
   if (images && images.length > 0) {
     log(ctx, `🖼️ Images detected! Raw inference does not support vision. Routing to Cascade API...`);
-    const numericModelValue = MODEL_ENUM_TO_VALUE[modelEnum] || 1035;
+    const numericModelValue = MODEL_ENUM_TO_VALUE[modelEnum];
+    if (!numericModelValue) {
+      // The Cascade protobuf needs the numeric wire enum. Models without a known
+      // numeric must fail here rather than silently running on another model.
+      throw new Error(`Model ${modelEnum} has no known Cascade wire enum value — image input is not supported for it.`);
+    }
     // Cascade is the ONLY endpoint that natively supports the 'media' field for images.
     const text = await callSidecarChat(ctx, messages, numericModelValue, null, null, images);
     return { content: text, toolCalls: null };

--- a/test/resolveModel.test.js
+++ b/test/resolveModel.test.js
@@ -20,6 +20,12 @@ describe('resolveModel', () => {
     assert.equal(result.owned_by, 'anthropic');
   });
 
+  it('resolves Gemini 3.5 Flash tiers', () => {
+    assert.equal(resolveModel('antigravity-gemini-3.5-flash').value, 1040);
+    assert.equal(resolveModel('antigravity-gemini-3.5-flash-medium').value, 1041);
+    assert.equal(resolveModel('antigravity-gemini-3.5-flash-low').value, 1042);
+  });
+
   it('resolves hidden alias "antigravity" to default model', () => {
     const result = resolveModel('antigravity');
     assert.equal(result.key, DEFAULT_MODEL_KEY);
@@ -110,6 +116,12 @@ describe('resolveModel', () => {
   it('resolves short-form alias gemini-3-flash-agent', () => {
     const result = resolveModel('gemini-3-flash-agent');
     assert.equal(result.value, 1018);
+  });
+
+  it('resolves short-form alias gemini-3.5-flash tiers', () => {
+    assert.equal(resolveModel('gemini-3.5-flash').value, 1040);
+    assert.equal(resolveModel('gemini-3.5-flash-medium').value, 1041);
+    assert.equal(resolveModel('gemini-3.5-flash-low').value, 1042);
   });
 
   it('resolves short-form alias gpt-oss-120b-medium', () => {

--- a/test/resolveModel.test.js
+++ b/test/resolveModel.test.js
@@ -60,9 +60,17 @@ describe('resolveModel', () => {
     assert.equal(result.key, DEFAULT_MODEL_KEY);
   });
 
-  it('returns default for completely unknown model', () => {
+  // ── Unknown models ──
+  it('returns null for completely unknown model', () => {
     const result = resolveModel('gpt-4-turbo-preview-2024');
-    assert.equal(result.key, DEFAULT_MODEL_KEY);
+    assert.equal(result, null);
+  });
+
+  it('returns null for unknown antigravity-prefixed model', () => {
+    // Regression: the bare 'antigravity' alias used to partial-match any
+    // 'antigravity-*' id, silently routing unknown models to the default model.
+    const result = resolveModel('antigravity-gemini-9.9-ultra');
+    assert.equal(result, null);
   });
 
   // ── Result shape ──


### PR DESCRIPTION
## What

Two changes, split into two commits:

**1. `fix`: unknown model ids now return 404 instead of silently routing to the default model**

`resolveModel()` fell back to the default model (Claude Sonnet) for any unknown id. Worse, the partial-match loop matched the bare `antigravity` alias against *every* `antigravity-*` string — so a typo like `antigravity-gemini-3-flsh`, or any model id newer than the hardcoded table, silently ran on Sonnet while the caller believed it was talking to the model it asked for. That misrouting is essentially undiagnosable from the client side.

- `resolveModel()` skips the bare `antigravity` alias during partial match and returns `null` for unknown ids (explicit `antigravity` requests and the empty-model default are unchanged)
- the three handlers reply 404 in each provider's native error shape (`code: 'model_not_found'` / `type: 'not_found_error'` / `status: 'NOT_FOUND'`)
- same disease in `sidecar/raw.js`'s image path: `MODEL_ENUM_TO_VALUE[modelEnum] || 1035` — a model without a known Cascade wire enum now fails loudly instead of silently running on Sonnet

**2. `feat`: Gemini 3.5 Flash tiers (High/Medium/Low)**

| Model id | Enum | Internal value |
| --- | --- | --- |
| `antigravity-gemini-3.5-flash` | `MODEL_PLACEHOLDER_M132` | 1040 |
| `antigravity-gemini-3.5-flash-medium` | `MODEL_PLACEHOLDER_M20` | 1041 |
| `antigravity-gemini-3.5-flash-low` | `MODEL_PLACEHOLDER_M187` | 1042 |

Short-form aliases (`gemini-3.5-flash*`) follow the existing convention; README/GEMINI.md tables updated.

## Where the enums come from (and how to verify them)

The sidecar's `LanguageServerService/GetCascadeModelConfigData` RPC returns the authoritative model table — `clientModelConfigs[]` with `label` ↔ `modelOrAlias.model` (enum name) pairs. You can query it live through the bridge's own debug endpoint:

```bash
curl -s -X POST http://127.0.0.1:11435/v1/proxy \
  -H 'Content-Type: application/json' \
  -d '{"method":"GetCascadeModelConfigData","body":{}}'
```

Verified output on a current Antigravity build (2026-06-11):

```
"label": "Gemini 3.5 Flash (High)",   "modelOrAlias": {"model": "MODEL_PLACEHOLDER_M132"}
"label": "Gemini 3.5 Flash (Medium)", "modelOrAlias": {"model": "MODEL_PLACEHOLDER_M20"}
"label": "Gemini 3.5 Flash (Low)",    "modelOrAlias": {"model": "MODEL_PLACEHOLDER_M187"}
```

One honest caveat: that RPC exposes **string enum names only**, so the numeric values `1040–1042` are bridge-internal indices (they only round-trip `MODEL_MAP` → `VALUE_TO_MODEL_ENUM`). They are deliberately **not** added to the protobuf wire maps in `sidecar/raw.js` / `sidecar/proto.js`, because the real `codeium_common_pb.Model` wire numbers for these enums are unknown. Text inference sends the string enum and works; image requests for these models fail loudly via the new guard rather than silently degrading.

## Behavioral notes (please weigh in)

- **Breaking change:** clients that relied on unknown/typo'd model ids silently running on the default model will now get a 404. That reliance was almost certainly unintentional on the client side, but it may warrant a version-bump note. (Empty/missing `model` and the explicit `antigravity` alias still resolve to the default, unchanged.)
- **Image input on the 3.5 Flash tiers** currently fails with a descriptive error (no known Cascade wire enum) routed through each handler's existing error path, rather than a dedicated 400. Plumbing a per-handler "vision not supported" 400 touches the streaming state machinery in all three handlers — happy to do that here or as a follow-up if you prefer it.

## Suggested follow-up: dynamic model table

This table has drifted twice now (the `M84`→`M18` typo fixed in 837f493, and these missing 3.5 Flash entries). Since `GetCascadeModelConfigData` is queryable at runtime, the bridge could fetch it once at startup and merge the result into `MODEL_MAP` — hardcoded entries become a fallback instead of the source of truth, and new models appear without a release. Happy to attempt that as a follow-up PR if you're open to it.

## Testing

- `npm test`: 120/120 pass (118 before; adds regression tests for the alias partial-match trap and the new tiers)
- `npm run lint`: 0 errors (the 5 pre-existing warnings in `cascade.js`/`discovery.js` are untouched)
- Live-verified against a patched 1.1.79 install: all three 3.5 Flash tiers respond over the text path, and the enum table matches the live RPC output above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
